### PR TITLE
【翻译中】Top 6 web frameworks for Go as of 2017

### DIFF
--- a/sources/tech/20171115 Top 6 web frameworks for Go as of 2017.md
+++ b/sources/tech/20171115 Top 6 web frameworks for Go as of 2017.md
@@ -1,3 +1,4 @@
+【rxcai翻译中】
 ![](https://raw.githubusercontent.com/studygolang/GCTT/master/sources/1_9P9_09xfijv7RRlA6C21eQ.jpeg)
 https://twitter.com/ThePracticalDev/status/930878898245722112
 


### PR DESCRIPTION
【翻译中】Top 6 web frameworks for Go as of 2017
认领翻译